### PR TITLE
Clarify known language selector

### DIFF
--- a/exercises/pronouns.html
+++ b/exercises/pronouns.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="el">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/exercises/verbs.html
+++ b/exercises/verbs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="el">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="el">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,15 +10,15 @@
 <div class="container">
     <header>
         <div class="language-selector">
-            <label for="languageSelect">
-                <select id="languageSelect" onchange="changeLanguage(this.value)">
-                    <option value="en">English</option>
-                    <option value="ru">Русский</option>
-                </select>
-            </label>
+            <label for="languageSelect">Γλώσσα που γνωρίζεις:</label>
+            <select id="languageSelect" onchange="changeLanguage(this.value)">
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+            </select>
         </div>
         <h1>Μάθε Ελληνικά</h1>
         <p class="subtitle">Κατακτήστε την ελληνική γλώσσα μέσω διαδραστικών ασκήσεων</p>
+        <p class="language-note">Επιλέξτε μια γλώσσα που ήδη γνωρίζετε. Θα χρησιμοποιηθεί για συμβουλές.</p>
     </header>
 
     <main>

--- a/styles.css
+++ b/styles.css
@@ -69,6 +69,12 @@ h1 {
     color: #666;
 }
 
+.language-note {
+    font-size: 0.9em;
+    color: #666;
+    margin-top: 10px;
+}
+
 .modules {
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- set `lang="el"` on main and exercise pages
- clarify that language selector represents a known language for hints
- style explanatory note for the selector

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5959a1fa08321a56888177de00ddb