### PR TITLE
Add GitHub Pages workflow with asset cache busting

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+env:
+  PUBLISH_DIR: .
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Versionize HTML asset references
+        run: scripts/versionize.sh
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ env.PUBLISH_DIR }}
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ To run the project locally:
 1. Open `index.html` in a web browser
 2. No build process or dependencies are required
 3. All exercises work offline once loaded
+
+## Deployment
+
+Every push to `main` automatically deploys the site to GitHub Pages. During the
+workflow run the [`scripts/versionize.sh`](scripts/versionize.sh) script appends
+the current commit's short hash as a `?v=<hash>` query string to all local
+`.css` and `.js` references in the HTML files so browsers always fetch the
+latest assets.
+
+The workflow publishes the directory indicated by the `PUBLISH_DIR` environment
+variable (default: repository root). If your site lives in a different
+subdirectory, edit `.github/workflows/pages.yml` and change `PUBLISH_DIR` to the
+folder you want to publish.

--- a/scripts/versionize.sh
+++ b/scripts/versionize.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PUBLISH_DIR="${PUBLISH_DIR:-.}"
+HASH="$(git rev-parse --short HEAD)"
+
+find "$PUBLISH_DIR" -name '*.html' -print0 | while IFS= read -r -d '' file; do
+  perl -0 -i -pe "s{(href|src)=[\"'](?!https?:|//)([^\"']+\.(?:css|js))(?:\\?[^\"']*)?[\"']}{\1=\"\2?v=$HASH\"}g" "$file"
+done


### PR DESCRIPTION
## Summary
- add `pages.yml` workflow to deploy to GitHub Pages and rewrite asset references with the current commit hash
- create `scripts/versionize.sh` to inject cache-busting query strings into local CSS/JS links
- document GitHub Pages deployment and the `PUBLISH_DIR` option in the README

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59d5714048321a82f1f716f5b3f0f