### PR TITLE
Adjust word form input mobile text handling

### DIFF
--- a/src/components/exercises/word-form/WordFormInput.tsx
+++ b/src/components/exercises/word-form/WordFormInput.tsx
@@ -162,11 +162,14 @@ function InputField({
 	return (
 		<div className='relative'>
 			<input
+				autoCapitalize='none'
 				autoComplete='off'
+				autoCorrect='off'
 				className={inputStyles}
 				data-status={status}
 				data-testid='exercise-input'
 				disabled={disabled && status !== 'REQUIRE_CORRECTION'}
+				inputMode='text'
 				onBlur={onBlur}
 				onChange={onChange}
 				onFocus={onFocus}


### PR DESCRIPTION
## Summary
- disable smartphone hints on the word exercise answer field
- explicitly mark the field as plain text input for better mobile keyboard behavior
- format the word-form input component to satisfy linting requirements

## Testing
- pnpm validate *(fails: Playwright browsers unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d06a1fda08832199f61c1d07c8622a