### PR TITLE
Align routing utilities with HashRouter

### DIFF
--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -58,7 +58,7 @@ This document explains the purpose of each file in the **Learn Greek** applicati
 - **main.tsx** - main application entry point
   - React Query Client setup for API request caching
   - MSW (Mock Service Worker) initialization for translation API mocks
-  - Providers: QueryClient, LanguageProvider, BrowserRouter
+  - Providers: QueryClient, LanguageProvider, HashRouter
   - React DevTools for query debugging
 
 ### Routing and components

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
 import {StrictMode} from 'react'
 import {createRoot} from 'react-dom/client'
-import {BrowserRouter} from 'react-router'
+import {HashRouter} from 'react-router'
 import {App} from './App'
 
 const queryClient = new QueryClient()
@@ -34,9 +34,9 @@ function renderApp() {
 			<StrictMode>
 				<QueryClientProvider client={queryClient}>
 					<ReactQueryDevtools initialIsOpen={false} />
-					<BrowserRouter basename={import.meta.env.BASE_URL}>
+					<HashRouter>
 						<App />
-					</BrowserRouter>
+					</HashRouter>
 				</QueryClientProvider>
 			</StrictMode>
 		)

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -2,7 +2,7 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {type RenderOptions, render as rtlRender} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type {PropsWithChildren, ReactElement} from 'react'
-import {BrowserRouter} from 'react-router'
+import {HashRouter} from 'react-router'
 
 export const queryClient = new QueryClient({
 	defaultOptions: {
@@ -16,14 +16,21 @@ export function render(
 		reactStrictMode: true
 	}
 ) {
-	window.history.pushState({}, '', route)
+	const normalizedRoute = route?.startsWith('#')
+		? route.slice(1)
+		: (route ?? '/')
+	const formattedRoute = normalizedRoute.startsWith('/')
+		? normalizedRoute
+		: `/${normalizedRoute}`
+
+	window.location.hash = `#${formattedRoute}`
 
 	return {
 		user: userEvent.setup(),
 		...rtlRender(ui, {
 			wrapper: ({children}: PropsWithChildren) => (
 				<QueryClientProvider client={queryClient}>
-					<BrowserRouter>{children}</BrowserRouter>
+					<HashRouter>{children}</HashRouter>
 				</QueryClientProvider>
 			),
 			...options

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1,4 +1,5 @@
 import {expect, test} from '@playwright/test'
+import {ROUTES} from './fixtures/selectors'
 
 test.describe('App', () => {
 	test('loads without errors', async ({page}) => {
@@ -9,7 +10,7 @@ test.describe('App', () => {
 			}
 		})
 
-		await page.goto('/')
+		await page.goto(ROUTES.home)
 
 		// Basic render check
 		await expect(page.locator('body')).toBeVisible()

--- a/tests/core/navigation.spec.ts
+++ b/tests/core/navigation.spec.ts
@@ -47,7 +47,7 @@ test.describe('Navigation - Advanced', () => {
 		const exercisePage = new ExercisePage(page)
 
 		// Direct navigation to exercise should work
-		await page.goto('/exercise/verbs-be')
+		await page.goto(ROUTES.exercisePath('verbs-be'))
 		await exercisePage.expectPageLoaded()
 
 		// Should be able to navigate back

--- a/tests/core/theme.spec.ts
+++ b/tests/core/theme.spec.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '@playwright/test'
-import {SELECTORS} from '../fixtures/selectors'
+import {ROUTES, SELECTORS} from '../fixtures/selectors'
 import {THEMES, UI_TEXT, VIEWPORT_SIZES} from '../fixtures/test-data'
 import {HomePage} from '../pages/HomePage'
 
@@ -90,7 +90,7 @@ test.describe('Theme - Persistence', () => {
 
 		// Navigate to exercises page
 		await homePage.clickExercisesCard()
-		await expect(page).toHaveURL('/exercises')
+		await expect(page).toHaveURL(ROUTES.exercises)
 
 		// Theme should persist
 		await expect(page.locator('html')).toHaveAttribute(
@@ -99,7 +99,7 @@ test.describe('Theme - Persistence', () => {
 		)
 
 		// Navigate back to home
-		await page.goto('/')
+		await page.goto(ROUTES.home)
 		await homePage.expectTheme(THEMES.dark)
 	})
 })

--- a/tests/fixtures/helpers.ts
+++ b/tests/fixtures/helpers.ts
@@ -1,5 +1,5 @@
 import type {Page} from '@playwright/test'
-import {DATA_ATTRIBUTES, SELECTORS} from './selectors'
+import {DATA_ATTRIBUTES, ROUTES, SELECTORS} from './selectors'
 import {TIMEOUTS, VIEWPORT_SIZES} from './test-data'
 
 // Regex constants for performance
@@ -107,7 +107,7 @@ export class TestHelpers {
 	 * Navigate to home page and wait for load
 	 */
 	async goHome() {
-		await this.page.goto('/')
+		await this.page.goto(ROUTES.home)
 		await this.page.locator(SELECTORS.mainHeading).waitFor()
 	}
 
@@ -115,7 +115,7 @@ export class TestHelpers {
 	 * Navigate to exercises page and wait for load
 	 */
 	async goToExercises() {
-		await this.page.goto('/exercises')
+		await this.page.goto(ROUTES.exercises)
 		await this.page.locator(SELECTORS.navCardExercises).first().waitFor()
 	}
 

--- a/tests/fixtures/selectors.ts
+++ b/tests/fixtures/selectors.ts
@@ -3,6 +3,18 @@
  * Uses data-testid attributes instead of text-based selectors for language independence
  */
 
+const HASH_PREFIX = '/#'
+
+const normalizePath = (path: string) =>
+	path.startsWith('/') ? path : `/${path}`
+
+const withHashPath = (path: string) => {
+	const normalized = normalizePath(path)
+	return normalized === '/' ? `${HASH_PREFIX}/` : `${HASH_PREFIX}${normalized}`
+}
+
+const withHashRegex = (path: string) => new RegExp(withHashPath(path))
+
 export const SELECTORS = {
 	// Navigation and Layout
 	navCardExercises: '[data-testid="nav-card-exercises"]',
@@ -72,8 +84,9 @@ export const CSS_CLASSES = {
  * Route patterns for URL validation
  */
 export const ROUTES = {
-	home: '/',
-	exercises: '/exercises',
-	exerciseVerbsBe: /\/exercise\/verbs-be/,
-	exerciseVerbsHave: /\/exercise\/verbs-have/
+	home: withHashPath('/'),
+	exercises: withHashPath('/exercises'),
+	exercisePath: (slug: string) => withHashPath(`/exercise/${slug}`),
+	exerciseVerbsBe: withHashRegex('/exercise/verbs-be'),
+	exerciseVerbsHave: withHashRegex('/exercise/verbs-have')
 } as const


### PR DESCRIPTION
## Summary
- drop the unused basename on the HashRouter so GitHub Pages links no longer include the repo path twice
- update the shared test renderer to seed window.location.hash the way HashRouter expects
- add hash-aware route helpers and update the Playwright suite to navigate and assert against the new URLs

## Testing
- `pnpm lint`
- `pnpm test:ci`
- `pnpm test:e2e:ci` *(fails: Playwright browsers are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f5a7eec48321993d321095ba15d5