### PR TITLE
Refactor app shell for nested routes

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -46,7 +46,10 @@ This document captures the refactor-first plan for aligning the Learn Greek appl
    - Reducer logic now routes through small, intention-revealing handlers (`handleAnswerCorrect`, `handleAdvance`, etc.) to satisfy Biome's complexity guardrails and keep future unit tests focused.
    - The `useWordFormExercise` view-model is composed from dedicated helper hooks (initialisation, derived selectors, timers, and event handlers) that isolate side effects while honouring React's Rules of Hooks.
    - Presentation is split into thin render helpers, keeping `ExerciseRenderer` under the 50-line limit and allowing completion/error states to be reused in Playwright/Vitest harnesses.
-3. Standardize layout and shell components, limit cross-module imports, and prepare for route-based code splitting.
+3. ✅ Standardize layout and shell components, limit cross-module imports, and prepare for route-based code splitting.
+   - Introduced an `AppShell` wrapper that hosts the header, main outlet, and footer behind a shared `LayoutProvider`.
+   - Centralised routing in `app/routes/AppRoutes` to keep page imports isolated and enable nested layout-aware route definitions.
+   - Shifted suspense fallbacks into the shell so lazy routes render within a consistent frame while code splitting remains opt-in per page.
 
 ### Phase 2 – Domain and data layer
 1. Define exercise domain models and adapters that transform raw JSON or API payloads into view models shared by exercises and library listings.

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -65,14 +65,14 @@ This document explains the purpose of each file in the **Learn Greek** applicati
   - `AppErrorBoundary.tsx` – top-level error boundary showing `LoadingOrError`
   - `QueryDevtools.tsx` – lazy React Query Devtools loader (development only)
   - `queryClient.ts` – shared query client factory with sensible defaults
+  - `routes/AppRoutes.tsx` – centralised route definitions with lazy page loading and nested shell layout
+  - `shell/AppShell.tsx` – shared header/main/footer wrapper that manages the layout context and suspense boundaries
 - **config/environment.ts** – runtime feature flags (router mode, MSW, devtools)
 
 ### Routing and components
 
-- **App.tsx** – root component with routing
-  - Uses React Router 7 for navigation between HomePage, ExerciseLibrary, ExerciseBuilder
-  - Lazy loading for exercise pages (code splitting)
-  - Suspense for loading states while translations/data resolve
+- **App.tsx** – delegates to `AppRoutes` for navigation
+  - Keeps the root component thin so the shell and routing concerns live in `app/`
 
 ### Pages (pages/)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,55 +1,5 @@
-import {lazy, Suspense} from 'react'
-import {Navigate, Route, Routes} from 'react-router'
-import {LoadingOrError} from '@/components/LoadingOrError'
-import {Footer} from '@/components/layout/Footer'
-import {Header} from '@/components/layout/Header'
-import {LayoutProvider} from '@/contexts/LayoutContext'
-import {useLayout} from '@/hooks/useLayout'
-import {HomePage} from '@/pages/HomePage'
-
-const ExerciseLibrary = lazy(async () =>
-	import('@/pages/ExerciseLibrary').then(m => ({default: m.ExerciseLibrary}))
-)
-
-const ExerciseBuilder = lazy(async () =>
-	import('@/pages/ExerciseBuilder').then(m => ({default: m.ExerciseBuilder}))
-)
-
-const ExercisePage = lazy(async () =>
-	import('@/pages/ExercisePage').then(m => ({default: m.ExercisePage}))
-)
-
-const LearnPage = lazy(async () =>
-	import('@/pages/LearnPage').then(m => ({default: m.LearnPage}))
-)
-
-function AppContent() {
-	const {headerEnabled} = useLayout()
-
-	return (
-		<div className='flex min-h-screen flex-col'>
-			<Header />
-			<Suspense fallback={<LoadingOrError />}>
-				<main className={`flex-1 ${headerEnabled ? 'pt-16' : 'pt-0'}`}>
-					<Routes>
-						<Route element={<HomePage />} index={true} />
-						<Route element={<ExerciseLibrary />} path='/exercises' />
-						<Route element={<ExercisePage />} path='/exercise/:exerciseId' />
-						<Route element={<LearnPage />} path='/learn/:exerciseId' />
-						<Route element={<ExerciseBuilder />} path='/builder' />
-						<Route element={<Navigate replace={true} to='/' />} path='*' />
-					</Routes>
-				</main>
-			</Suspense>
-			<Footer />
-		</div>
-	)
-}
+import {AppRoutes} from './app/routes/AppRoutes'
 
 export function App() {
-	return (
-		<LayoutProvider>
-			<AppContent />
-		</LayoutProvider>
-	)
+	return <AppRoutes />
 }

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -1,0 +1,41 @@
+import {lazy} from 'react'
+import {Navigate, Route, Routes} from 'react-router'
+import {HomePage} from '@/pages/HomePage'
+import {AppShell} from '../shell/AppShell'
+
+const ExerciseLibrary = lazy(async () =>
+	import('@/pages/ExerciseLibrary').then(module => ({
+		default: module.ExerciseLibrary
+	}))
+)
+
+const ExerciseBuilder = lazy(async () =>
+	import('@/pages/ExerciseBuilder').then(module => ({
+		default: module.ExerciseBuilder
+	}))
+)
+
+const ExercisePage = lazy(async () =>
+	import('@/pages/ExercisePage').then(module => ({
+		default: module.ExercisePage
+	}))
+)
+
+const LearnPage = lazy(async () =>
+	import('@/pages/LearnPage').then(module => ({default: module.LearnPage}))
+)
+
+export function AppRoutes() {
+	return (
+		<Routes>
+			<Route element={<AppShell />} path='/'>
+				<Route element={<HomePage />} index={true} />
+				<Route element={<ExerciseLibrary />} path='exercises' />
+				<Route element={<ExercisePage />} path='exercise/:exerciseId' />
+				<Route element={<LearnPage />} path='learn/:exerciseId' />
+				<Route element={<ExerciseBuilder />} path='builder' />
+				<Route element={<Navigate replace={true} to='/' />} path='*' />
+			</Route>
+		</Routes>
+	)
+}

--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -1,0 +1,31 @@
+import {Suspense} from 'react'
+import {Outlet} from 'react-router'
+import {LoadingOrError} from '@/components/LoadingOrError'
+import {Footer} from '@/components/layout/Footer'
+import {Header} from '@/components/layout/Header'
+import {LayoutProvider} from '@/contexts/LayoutContext'
+import {useLayout} from '@/hooks/useLayout'
+
+function AppShellContent() {
+	const {headerEnabled} = useLayout()
+
+	return (
+		<div className='flex min-h-screen flex-col'>
+			<Header />
+			<main className={`flex-1 ${headerEnabled ? 'pt-16' : 'pt-0'}`}>
+				<Suspense fallback={<LoadingOrError />}>
+					<Outlet />
+				</Suspense>
+			</main>
+			<Footer />
+		</div>
+	)
+}
+
+export function AppShell() {
+	return (
+		<LayoutProvider>
+			<AppShellContent />
+		</LayoutProvider>
+	)
+}


### PR DESCRIPTION
## Summary
- introduce an AppShell wrapper that owns header, footer, layout context, and suspense boundaries for lazy routes
- centralize route definitions in app/routes/AppRoutes to isolate page imports and support nested layouts
- update roadmap and architecture docs to capture the new shell structure and completed Phase 1 milestone

## Testing
- pnpm validate *(fails: Playwright browsers are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a96ddecc83218966b6b39157f42a