### PR TITLE
Improve Playwright auto-advance stability

### DIFF
--- a/src/components/exercises/shared/ExerciseHeader.tsx
+++ b/src/components/exercises/shared/ExerciseHeader.tsx
@@ -124,6 +124,8 @@ function ProgressBar({
 				</span>
 				<span
 					className='font-medium text-gray-900 text-sm dark:text-white'
+					data-progress-current={progress.current}
+					data-progress-total={progress.total}
 					data-testid='progress-text'
 				>
 					{progress.current} {t('exercise.progressOf')} {progress.total}

--- a/tests/fixtures/selectors.ts
+++ b/tests/fixtures/selectors.ts
@@ -68,7 +68,9 @@ export const DATA_ATTRIBUTES = {
 	inputStatus: 'data-status',
 	autoAdvanceEnabled: 'data-enabled',
 	userLangSelected: 'data-selected',
-	dropdownOpen: 'data-is-open'
+	dropdownOpen: 'data-is-open',
+	progressCurrent: 'data-progress-current',
+	progressTotal: 'data-progress-total'
 } as const
 
 /**

--- a/tests/pages/ExercisePage.ts
+++ b/tests/pages/ExercisePage.ts
@@ -1,5 +1,5 @@
 import {expect, type Locator, type Page} from '@playwright/test'
-import {TestHelpers} from '../fixtures/helpers'
+import {type ProgressSnapshot, TestHelpers} from '../fixtures/helpers'
 import {SELECTORS} from '../fixtures/selectors'
 import {EXERCISE_STATUS, TIMEOUTS} from '../fixtures/test-data'
 
@@ -14,6 +14,7 @@ const COMPLETION_MESSAGE_REGEX =
 export class ExercisePage {
 	private readonly page: Page
 	private readonly helpers: TestHelpers
+	private progressBaseline: ProgressSnapshot | null = null
 
 	constructor(page: Page) {
 		this.page = page
@@ -62,10 +63,12 @@ export class ExercisePage {
 
 	async submitAnswer(answer: string) {
 		await this.fillInput(answer)
+		this.progressBaseline = await this.helpers.getProgressSnapshot()
 		await this.input.press('Enter')
 	}
 
 	async clickSubmitButton() {
+		this.progressBaseline = await this.helpers.getProgressSnapshot()
 		await this.submitButton.click()
 	}
 
@@ -82,7 +85,8 @@ export class ExercisePage {
 	}
 
 	async waitForAutoAdvance() {
-		await this.helpers.waitForAutoAdvance()
+		await this.helpers.waitForAutoAdvance(this.progressBaseline)
+		this.progressBaseline = null
 	}
 
 	async waitForAnswerProcessing(statuses?: readonly ExerciseStatusValue[]) {


### PR DESCRIPTION
## Summary
- annotate the exercise progress indicator with deterministic data attributes for E2E assertions
- add snapshot helpers so Playwright waits for progress and status changes instead of fixed timeouts
- capture progress baselines in the Exercise page object before submitting answers to reuse in waits

## Testing
- pnpm validate
- CI=1 pnpm test:e2e:ci

------
https://chatgpt.com/codex/tasks/task_e_68d3d70039488321b7d3830ec6b743d5