### PR TITLE
Add tests for hooks and API fallbacks

### DIFF
--- a/src/api/fallbacks.test.ts
+++ b/src/api/fallbacks.test.ts
@@ -1,0 +1,127 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+type FallbackModule = typeof import('./fallbacks')
+
+afterEach(() => {
+        vi.resetModules()
+        vi.doUnmock('@/mocks/data/translations.json')
+        vi.doUnmock('@/domain/exercises/adapters')
+})
+
+async function loadFallbacks() {
+        return import('./fallbacks') as Promise<FallbackModule>
+}
+
+describe('resolveFallbackResponse', () => {
+        it('returns trimmed translations for GET requests', async () => {
+                const {resolveFallbackResponse} = await loadFallbacks()
+                const url = new URL('https://example.com/api/translations?lang=ru&keys= app.title ,unknown, ')
+
+                const result = resolveFallbackResponse({
+                        url,
+                        method: 'GET'
+                })
+
+                expect(result).toEqual({
+                        type: 'success',
+                        data: {
+                                translations: {
+                                        'app.title': expect.any(String)
+                                }
+                        }
+                })
+        })
+
+        it('falls back to English translations when requested language lacks entries', async () => {
+                vi.doMock('@/mocks/data/translations.json', () => ({
+                        default: {
+                                en: {'app.title': 'English title'},
+                                ru: {}
+                        }
+                }))
+
+                const {resolveFallbackResponse} = await loadFallbacks()
+                const result = resolveFallbackResponse({
+                        url: new URL('https://example.com/api/translations'),
+                        method: 'POST',
+                        body: {language: 'ru', keys: ['app.title']}
+                })
+
+                expect(result).toEqual({
+                        type: 'success',
+                        data: {
+                                translations: {
+                                        'app.title': 'English title'
+                                }
+                        }
+                })
+        })
+
+        it('lists enabled exercises ordered alphabetically', async () => {
+                const {resolveFallbackResponse} = await loadFallbacks()
+                const result = resolveFallbackResponse({
+                        url: new URL('https://example.com/api/exercises'),
+                        method: 'GET'
+                })
+
+                expect(result?.type).toBe('success')
+                expect(Array.isArray(result?.data)).toBe(true)
+
+                const metadata = result?.data as Array<{title: string}>
+                const sorted = [...metadata].sort((a, b) => a.title.localeCompare(b.title))
+
+                expect(metadata).toEqual(sorted)
+        })
+
+        it('returns 404 when exercise is not found', async () => {
+                const {resolveFallbackResponse} = await loadFallbacks()
+                const result = resolveFallbackResponse({
+                        url: new URL('https://example.com/api/exercises/non-existent'),
+                        method: 'GET'
+                })
+
+                expect(result).toEqual({
+                        type: 'error',
+                        status: 404,
+                        message: 'Exercise non-existent not found'
+                })
+        })
+
+        it('returns 403 when exercise is disabled', async () => {
+                vi.doMock('@/domain/exercises/adapters', async () => {
+                        const actual = await vi.importActual<
+                                typeof import('@/domain/exercises/adapters')
+                        >('@/domain/exercises/adapters')
+
+                        return {
+                                ...actual,
+                                toWordFormExerciseWithDefaults: (exercise: unknown) => {
+                                        const normalized =
+                                                actual.toWordFormExerciseWithDefaults(
+                                                        exercise as Parameters<
+                                                                typeof actual.toWordFormExerciseWithDefaults
+                                                        >[0]
+                                                )
+
+                                        if (normalized.id === 'verbs-be') {
+                                                return {...normalized, enabled: false}
+                                        }
+
+                                        return normalized
+                                }
+                        }
+                })
+
+                const {resolveFallbackResponse} = await loadFallbacks()
+                const result = resolveFallbackResponse({
+                        url: new URL('https://example.com/api/exercises/verbs-be'),
+                        method: 'GET'
+                })
+
+                expect(result).toEqual({
+                        type: 'error',
+                        status: 403,
+                        message: 'Exercise verbs-be is not available'
+                })
+        })
+})

--- a/src/api/texts.test.ts
+++ b/src/api/texts.test.ts
@@ -1,0 +1,40 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+const requestJson = vi.fn()
+
+vi.mock('./httpClient', () => ({
+        requestJson
+}))
+
+describe('getTranslations', () => {
+        afterEach(() => {
+                requestJson.mockReset()
+        })
+
+        it('fetches translations with provided keys and language', async () => {
+                requestJson.mockResolvedValue({
+                        translations: {"app.title": 'Learn Greek'}
+                })
+
+                const {getTranslations} = await import('./texts')
+                const result = await getTranslations('en', ['app.title'])
+
+                expect(requestJson).toHaveBeenCalledWith('/api/translations', {
+                        method: 'POST',
+                        body: {language: 'en', keys: ['app.title']}
+                })
+                expect(result).toEqual({"app.title": 'Learn Greek'})
+        })
+
+        it('throws when server returns invalid translation payload', async () => {
+                requestJson.mockResolvedValue({
+                        translations: {"app.title": 123}
+                })
+
+                const {getTranslations} = await import('./texts')
+
+                await expect(
+                        getTranslations('en', ['app.title'])
+                ).rejects.toThrowError(/Invalid/)
+        })
+})

--- a/src/hooks/__tests__/useExercises.test.ts
+++ b/src/hooks/__tests__/useExercises.test.ts
@@ -1,0 +1,79 @@
+import {renderHook} from '@testing-library/react'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+type QueryModule = typeof import('@tanstack/react-query')
+
+const mockUseQuery = vi.fn()
+const mockWordFormExerciseQueryOptions = vi.fn(
+        (id: string | undefined) => ({queryKey: ['exercise', id]})
+)
+
+vi.mock('@tanstack/react-query', async () => {
+        const actual = await vi.importActual<QueryModule>('@tanstack/react-query')
+
+        return {
+                ...actual,
+                useQuery: mockUseQuery
+        }
+})
+
+vi.mock('@/domain/exercises/queryOptions', () => ({
+        exerciseLibraryQueryOptions: {queryKey: ['exercise-library']} as const,
+        wordFormExerciseQueryOptions: mockWordFormExerciseQueryOptions
+}))
+
+async function loadModule() {
+        const module = await import('@/hooks/useExercises')
+        return module
+}
+
+describe('useExercises', () => {
+        afterEach(() => {
+                mockUseQuery.mockReset()
+                mockWordFormExerciseQueryOptions.mockClear()
+        })
+
+        it('delegates to useQuery with library query options', async () => {
+                const queryResult = {data: ['exercise-a']}
+                mockUseQuery.mockReturnValue(queryResult)
+
+                const {useExercises} = await loadModule()
+                const {result, unmount} = renderHook(() => useExercises())
+
+                expect(mockUseQuery).toHaveBeenCalledWith({
+                        queryKey: ['exercise-library']
+                })
+                expect(result.current).toBe(queryResult)
+
+                unmount()
+        })
+
+        it('requests exercise data using identifier-specific query options', async () => {
+                const queryResult = {data: {id: 'exercise-42'}}
+                mockUseQuery.mockReturnValue(queryResult)
+
+                const {useExercise} = await loadModule()
+                const {result, unmount} = renderHook(() => useExercise('exercise-42'))
+
+                expect(mockWordFormExerciseQueryOptions).toHaveBeenCalledWith('exercise-42')
+                expect(mockUseQuery).toHaveBeenCalledWith({
+                        queryKey: ['exercise', 'exercise-42']
+                })
+                expect(result.current).toBe(queryResult)
+
+                unmount()
+        })
+
+        it('passes undefined ids through to the query option factory', async () => {
+                const queryResult = {data: null}
+                mockUseQuery.mockReturnValue(queryResult)
+
+                const {useExercise} = await loadModule()
+                const {result, unmount} = renderHook(() => useExercise(undefined))
+
+                expect(mockWordFormExerciseQueryOptions).toHaveBeenCalledWith(undefined)
+                expect(result.current).toBe(queryResult)
+
+                unmount()
+        })
+})

--- a/src/hooks/__tests__/useHintState.test.ts
+++ b/src/hooks/__tests__/useHintState.test.ts
@@ -1,0 +1,49 @@
+import {act, renderHook} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+import {useHintState} from '@/hooks/useHintState'
+
+describe('useHintState', () => {
+        it('toggles hint visibility state', () => {
+                const {result} = renderHook(() => useHintState())
+
+                expect(result.current.isHintVisible('hint-1')).toBe(false)
+
+                act(() => {
+                        result.current.toggleHint('hint-1')
+                })
+
+                expect(result.current.isHintVisible('hint-1')).toBe(true)
+
+                act(() => {
+                        result.current.toggleHint('hint-1')
+                })
+
+                expect(result.current.isHintVisible('hint-1')).toBe(false)
+        })
+
+        it('shows, hides and clears individual hints without affecting others', () => {
+                const {result} = renderHook(() => useHintState())
+
+                act(() => {
+                        result.current.showHint('alpha')
+                        result.current.showHint('beta')
+                })
+
+                expect(result.current.isHintVisible('alpha')).toBe(true)
+                expect(result.current.isHintVisible('beta')).toBe(true)
+
+                act(() => {
+                        result.current.hideHint('alpha')
+                })
+
+                expect(result.current.isHintVisible('alpha')).toBe(false)
+                expect(result.current.isHintVisible('beta')).toBe(true)
+
+                act(() => {
+                        result.current.hideAllHints()
+                })
+
+                expect(result.current.isHintVisible('alpha')).toBe(false)
+                expect(result.current.isHintVisible('beta')).toBe(false)
+        })
+})

--- a/src/hooks/__tests__/usePulseEffect.test.ts
+++ b/src/hooks/__tests__/usePulseEffect.test.ts
@@ -1,0 +1,33 @@
+import {act, renderHook} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+import {usePulseEffect} from '@/hooks/usePulseEffect'
+
+describe('usePulseEffect', () => {
+        it('provides null as the initial pulse state', () => {
+                const {result} = renderHook(() => usePulseEffect())
+
+                expect(result.current.pulseState).toBeNull()
+        })
+
+        it('updates and clears the pulse state when triggered', () => {
+                const {result} = renderHook(() => usePulseEffect())
+
+                act(() => {
+                        result.current.triggerPulse('correct')
+                })
+
+                expect(result.current.pulseState).toBe('correct')
+
+                act(() => {
+                        result.current.triggerPulse('incorrect')
+                })
+
+                expect(result.current.pulseState).toBe('incorrect')
+
+                act(() => {
+                        result.current.clearPulse()
+                })
+
+                expect(result.current.pulseState).toBeNull()
+        })
+})


### PR DESCRIPTION
## Summary
- add regression tests for the hint and pulse state hooks
- cover the exercises query hook wiring to react-query
- verify translation fetching and fallback API behaviour with dedicated unit tests

## Testing
- pnpm test:ci *(fails: coverage thresholds not yet met)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d01eaea88321ac2757e944bfcfad