### PR TITLE
Add tests for hint and word form exercise components

### DIFF
--- a/src/components/exercises/shared/ExerciseHeader.test.tsx
+++ b/src/components/exercises/shared/ExerciseHeader.test.tsx
@@ -1,0 +1,64 @@
+import {screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {describe, expect, it, vi} from 'vitest'
+import {ExerciseHeader} from './ExerciseHeader'
+import {render} from '@/test-utils'
+
+vi.mock('@/hooks/useTranslations', () => ({
+        useTranslations: () => ({
+                t: (key: string) => key,
+                status: 'complete' as const,
+                missingKeys: [] as string[]
+        })
+}))
+
+describe('ExerciseHeader', () => {
+        it('renders title, block name and progress information', () => {
+                render(
+                        <ExerciseHeader
+                                blockName='Ενεστώτας'
+                                progress={{current: 3, total: 5}}
+                                title='Είμαι'
+                        />
+                )
+
+                expect(screen.getByText('Είμαι')).toBeInTheDocument()
+                expect(screen.getByText('Ενεστώτας')).toBeInTheDocument()
+                expect(screen.getByTestId('progress-text')).toHaveTextContent(
+                        '3 exercise.progressOf 5'
+                )
+                expect(screen.getByText('exercise.progress')).toBeInTheDocument()
+        })
+
+        it('invokes auto advance toggle when button is clicked', async () => {
+                const onToggle = vi.fn()
+                const user = userEvent.setup()
+
+                render(
+                        <ExerciseHeader
+                                autoAdvanceEnabled={false}
+                                onToggleAutoAdvance={onToggle}
+                                progress={{current: 1, total: 2}}
+                                title='Μελέτη'
+                        />
+                )
+
+                const toggle = screen.getByTestId('auto-advance-toggle')
+                expect(toggle).toHaveAttribute('data-enabled', 'false')
+
+                await user.click(toggle)
+
+                expect(onToggle).toHaveBeenCalledTimes(1)
+        })
+
+        it('hides back button when showBackButton is false', () => {
+                render(
+                        <ExerciseHeader
+                                showBackButton={false}
+                                title='Χωρίς επιστροφή'
+                        />
+                )
+
+                expect(screen.queryByTestId('exercise-back-button')).not.toBeInTheDocument()
+        })
+})

--- a/src/components/exercises/shared/HintSystem.test.tsx
+++ b/src/components/exercises/shared/HintSystem.test.tsx
@@ -1,0 +1,98 @@
+import {act, render, screen, waitFor} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {HintSystem, SimpleHint} from './HintSystem'
+import {useSettingsStore} from '@/stores/settings'
+import {DEFAULT_SETTINGS} from '@/types/settings'
+
+vi.mock('@/hooks/useTranslations', () => ({
+        useTranslations: () => ({
+                t: (key: string) => `t:${key}`,
+                status: 'complete' as const,
+                missingKeys: [] as string[]
+        })
+}))
+
+describe('HintSystem', () => {
+        beforeEach(() => {
+                act(() => {
+                        useSettingsStore.setState(() => ({...DEFAULT_SETTINGS}))
+                })
+        })
+
+        it('renders only primary text when no hints provided', () => {
+                render(
+                        <HintSystem
+                                hints={{}}
+                                primaryText='Γειά'
+                        />
+                )
+
+                expect(screen.getByText('Γειά')).toBeInTheDocument()
+                expect(screen.queryByRole('button')).not.toBeInTheDocument()
+        })
+
+        it('toggles hint visibility on click and closes when clicking outside', async () => {
+                const user = userEvent.setup()
+
+                render(
+                        <HintSystem
+                                hints={{en: 'Hello'}}
+                                placement='bottom'
+                                primaryText='Χαίρετε'
+                        />
+                )
+
+                const button = screen.getByRole('button', {
+                        name: 'Показать подсказку: Hello'
+                })
+
+                await user.click(button)
+
+                const tooltip = await screen.findByText('Hello')
+                expect(tooltip).toHaveClass('top-full')
+
+                await user.click(document.body)
+
+                await waitFor(() => {
+                        expect(screen.queryByText('Hello')).not.toBeInTheDocument()
+                })
+        })
+
+        it('uses language fallbacks when hint for current language is missing', async () => {
+                const user = userEvent.setup()
+
+                act(() => {
+                        useSettingsStore.getState().setUserLanguage('el')
+                })
+
+                render(
+                        <HintSystem
+                                hints={{en: 'Fallback hint'}}
+                                primaryText='λέξη'
+                        />
+                )
+
+                const button = screen.getByRole('button', {
+                        name: 'Показать подсказку: Fallback hint'
+                })
+
+                await user.click(button)
+                await screen.findByText('Fallback hint')
+        })
+
+        it('SimpleHint proxies props to HintSystem with generated hints', async () => {
+                const user = userEvent.setup()
+
+                render(
+                        <SimpleHint hint='Απάντηση'>Κείμενο</SimpleHint>
+                )
+
+                const button = screen.getByRole('button', {
+                        name: 'Показать подсказку: Απάντηση'
+                })
+
+                await user.click(button)
+                await screen.findByText('Απάντηση')
+        })
+})

--- a/src/components/exercises/word-form/ExerciseRenderer.test.tsx
+++ b/src/components/exercises/word-form/ExerciseRenderer.test.tsx
@@ -1,0 +1,225 @@
+import {render, screen} from '@testing-library/react'
+import type React from 'react'
+import {act} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {ExerciseRenderer} from './ExerciseRenderer'
+import type {WordFormViewState} from './hooks/useWordFormExercise'
+import type {PulseState} from '../shared/PulseEffect'
+import type {ExerciseEvent, WordFormExercise} from '@/types/exercises'
+import {useSettingsStore} from '@/stores/settings'
+import {DEFAULT_SETTINGS} from '@/types/settings'
+
+vi.mock('@/components/Head', () => ({
+        Head: ({children}: {children?: React.ReactNode}) => <>{children}</>
+}))
+
+const completionScreenMock = vi.fn()
+vi.mock('./CompletionScreen', () => ({
+        CompletionScreen: (props: Record<string, unknown>) => {
+                completionScreenMock(props)
+                return <div data-testid='completion-screen'>{props.exerciseTitle as string}</div>
+        }
+}))
+
+const exerciseContentMock = vi.fn()
+vi.mock('./ExerciseContent', () => ({
+        ExerciseContent: (props: Record<string, unknown>) => {
+                exerciseContentMock(props)
+                return <div data-testid='exercise-content' />
+        }
+}))
+
+vi.mock('@/hooks/useTranslations', () => ({
+        useTranslations: () => ({
+                t: (key: string) => key,
+                status: 'complete' as const,
+                missingKeys: [] as string[]
+        })
+}))
+
+describe('ExerciseRenderer', () => {
+        const exercise: WordFormExercise = {
+                enabled: true,
+                id: 'exercise-1',
+                type: 'word-form',
+                title: 'Είμαι',
+                titleI18n: {en: 'To be', ru: 'Быть'},
+                description: 'Description',
+                descriptionI18n: {en: 'Description', ru: 'Описание'},
+                tags: ['verbs'],
+                difficulty: 'a1',
+                estimatedTimeMinutes: 5,
+                settings: {
+                        autoAdvance: true,
+                        autoAdvanceDelayMs: 500,
+                        allowSkip: true,
+                        shuffleCases: false
+                },
+                blocks: [
+                        {
+                                id: 'present',
+                                name: 'Ενεστώτας',
+                                nameHintI18n: {en: 'Present'},
+                                cases: [
+                                        {
+                                                id: 'case-1',
+                                                prompt: 'εγώ ___',
+                                                promptHintI18n: {en: 'I'},
+                                                correct: ['είμαι'],
+                                                hint: 'ρήμα',
+                                                hintI18n: {en: 'verb'}
+                                        }
+                                ]
+                        }
+                ]
+        }
+
+        const baseState: WordFormViewState = {
+                answer: {
+                        value: '',
+                        isCorrect: null,
+                        showAnswer: false,
+                        incorrectAttempts: 0
+                },
+                autoAdvanceEnabled: true,
+                status: 'WAITING_INPUT',
+                progress: {completed: 0, current: 1, total: 1},
+                stats: {correct: 0, incorrect: 0},
+                hints: {name: false, prompt: false, additional: false},
+                startedAt: 1_000,
+                exercise,
+                currentBlock: exercise.blocks[0],
+                currentCase: exercise.blocks[0]?.cases[0]
+        }
+
+        const pulseState: PulseState = 'correct'
+
+        beforeEach(() => {
+                act(() => {
+                        useSettingsStore.setState(() => ({...DEFAULT_SETTINGS}))
+                })
+                completionScreenMock.mockReset()
+                exerciseContentMock.mockReset()
+        })
+
+        it('renders completion screen when exercise is completed', () => {
+                const handleEvent = vi.fn()
+                const state: WordFormViewState = {
+                        ...baseState,
+                        status: 'COMPLETED',
+                        stats: {correct: 3, incorrect: 1},
+                        progress: {completed: 1, current: 1, total: 1}
+                }
+
+                render(
+                        <ExerciseRenderer
+                                clearPulse={vi.fn()}
+                                handleAnswerChange={vi.fn()}
+                                handleAutoAdvanceToggle={vi.fn()}
+                                handleEvent={handleEvent}
+                                handleSubmit={vi.fn()}
+                                onExit={vi.fn()}
+                                pulseState={pulseState}
+                                state={state}
+                        />
+                )
+
+                expect(screen.getByTestId('completion-screen')).toHaveTextContent('To be')
+                const props = completionScreenMock.mock.calls.at(-1)?.[0] as {
+                        onRestart: () => void
+                        correctCount: number
+                        incorrectCount: number
+                        totalCases: number
+                }
+                expect(props.correctCount).toBe(3)
+                expect(props.incorrectCount).toBe(1)
+                expect(props.totalCases).toBe(1)
+
+                props.onRestart()
+                expect(handleEvent).toHaveBeenCalledWith({type: 'RESTART'})
+        })
+
+        it('shows fallback content when current case is missing', () => {
+                const state: WordFormViewState = {
+                        ...baseState,
+                        currentBlock: undefined,
+                        currentCase: undefined
+                }
+
+                render(
+                        <ExerciseRenderer
+                                clearPulse={vi.fn()}
+                                handleAnswerChange={vi.fn()}
+                                handleAutoAdvanceToggle={vi.fn()}
+                                handleEvent={vi.fn()}
+                                handleSubmit={vi.fn()}
+                                pulseState={null}
+                                state={state}
+                        />
+                )
+
+                expect(
+                        screen.getByText('error.couldNotLoadExercise')
+                ).toBeInTheDocument()
+                expect(exerciseContentMock).not.toHaveBeenCalled()
+        })
+
+        it('renders exercise content with interaction handlers', () => {
+                const handleSubmit = vi.fn()
+                const handleEvent = vi.fn<(event: ExerciseEvent) => void>()
+                const handleToggle = vi.fn()
+                const handleAnswerChange = vi.fn()
+                const clearPulse = vi.fn()
+
+                render(
+                        <ExerciseRenderer
+                                clearPulse={clearPulse}
+                                handleAnswerChange={handleAnswerChange}
+                                handleAutoAdvanceToggle={handleToggle}
+                                handleEvent={handleEvent}
+                                handleSubmit={handleSubmit}
+                                pulseState={pulseState}
+                                state={baseState}
+                        />
+                )
+
+                expect(screen.getByTestId('exercise-content')).toBeInTheDocument()
+                const props = exerciseContentMock.mock.calls.at(-1)?.[0] as Record<string, unknown>
+
+                expect(props?.onSubmit).toBe(handleSubmit)
+                expect(props?.onToggleAutoAdvance).toBe(handleToggle)
+                expect(props?.onAnswerChange).toBe(handleAnswerChange)
+                expect(props?.onPulseComplete).toBe(clearPulse)
+                expect(props?.exercise).toBe(baseState.exercise)
+
+                const onSkip = props?.onSkip as (() => void) | undefined
+                expect(onSkip).toBeTypeOf('function')
+                onSkip?.()
+                expect(handleEvent).toHaveBeenCalledWith({type: 'SKIP'})
+        })
+
+        it('prefers translated exercise title based on user language', () => {
+                act(() => {
+                        useSettingsStore.getState().setUserLanguage('ru')
+                })
+
+                const state: WordFormViewState = {
+                        ...baseState,
+                        status: 'COMPLETED'
+                }
+
+                render(
+                        <ExerciseRenderer
+                                clearPulse={vi.fn()}
+                                handleAnswerChange={vi.fn()}
+                                handleAutoAdvanceToggle={vi.fn()}
+                                handleEvent={vi.fn()}
+                                handleSubmit={vi.fn()}
+                                pulseState={pulseState}
+                                state={state}
+                        />
+                )
+
+                expect(screen.getByTestId('completion-screen')).toHaveTextContent('Быть')
+        })
+})

--- a/src/components/exercises/word-form/WordFormFeedback.test.tsx
+++ b/src/components/exercises/word-form/WordFormFeedback.test.tsx
@@ -1,0 +1,93 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+import {WordFormFeedback} from './WordFormFeedback'
+import type {ExerciseStatus} from '@/types/exercises'
+
+vi.mock('@/hooks/useTranslations', () => ({
+        useTranslations: () => ({
+                t: (key: string) => key,
+                status: 'complete' as const,
+                missingKeys: [] as string[]
+        })
+}))
+
+describe('WordFormFeedback', () => {
+        const baseProps = {
+                correctAnswers: ['είμαι'],
+                userAnswer: 'είμαι'
+        }
+
+        it('does not render when feedback is not required', () => {
+                const {container} = render(
+                        <WordFormFeedback
+                                {...baseProps}
+                                isCorrect={null}
+                                status='WAITING_INPUT'
+                        />
+                )
+
+                expect(container.firstChild).toBeNull()
+        })
+
+        it('renders success feedback with progress indicator', () => {
+                render(
+                        <WordFormFeedback
+                                {...baseProps}
+                                isCorrect={true}
+                                status='CORRECT_ANSWER'
+                        />
+                )
+
+                const heading = screen.getByText('exercise.correct', {
+                        exact: false,
+                        selector: 'span'
+                })
+                expect(heading).toHaveTextContent('exercise.correct')
+                expect(heading).toHaveTextContent('exercise.exclamationMark')
+                expect(screen.getByTitle('exercise.correctIcon')).toBeInTheDocument()
+                expect(
+                        screen.getByText('exercise.correctAnswerIs', {
+                                exact: false,
+                                selector: 'p'
+                        })
+                ).toHaveTextContent('είμαι')
+                const indicator = document.querySelector('.bg-green-400')
+                expect(indicator).toBeTruthy()
+        })
+
+        it('renders error feedback with correct answers list and instructions', () => {
+                render(
+                        <WordFormFeedback
+                                correctAnswers={['είμαι', 'είμαστε']}
+                                isCorrect={false}
+                                status='WRONG_ANSWER'
+                                userAnswer='λάθος'
+                        />
+                )
+
+                expect(screen.getByText('exercise.incorrect')).toBeInTheDocument()
+                expect(screen.getByTitle('exercise.incorrectIcon')).toBeInTheDocument()
+                expect(screen.getByText('exercise.yourAnswerIs λάθος')).toBeInTheDocument()
+                expect(screen.getByText('Σωστές απαντήσεις:')).toBeInTheDocument()
+                expect(screen.getByText('είμαι')).toBeInTheDocument()
+                expect(screen.getByText('είμαστε')).toBeInTheDocument()
+                expect(
+                        screen.getByText('exercise.enterCorrectToContinue')
+                ).toBeInTheDocument()
+        })
+
+        it('omits user answer text when value is empty', () => {
+                render(
+                        <WordFormFeedback
+                                correctAnswers={['είμαι']}
+                                isCorrect={false}
+                                status={'REQUIRE_CORRECTION' satisfies ExerciseStatus}
+                                userAnswer=''
+                        />
+                )
+
+                expect(
+                        screen.queryByText('exercise.yourAnswerIs')
+                ).not.toBeInTheDocument()
+        })
+})


### PR DESCRIPTION
## Summary
- add unit tests for the shared HintSystem, including fallbacks and tooltip toggling
- cover ExerciseHeader behaviour such as progress display, auto-advance toggling, and back button visibility
- add word-form specific tests for ExerciseRenderer and WordFormFeedback completion, fallback, and feedback flows

## Testing
- pnpm test:ci *(fails: coverage thresholds not yet met; underlying tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cffb6a488321a4f1efed3073101e