### PR TITLE
Ensure word-form input refocuses after feedback states

### DIFF
--- a/src/components/exercises/word-form/WordFormInput.tsx
+++ b/src/components/exercises/word-form/WordFormInput.tsx
@@ -207,12 +207,26 @@ function useWordFormInput({
 	const [isFocused, setIsFocused] = useState(false)
 
 	useEffect(() => {
+		if (!(autoFocus && inputRef.current)) {
+			return
+		}
+
 		if (
-			autoFocus &&
-			inputRef.current &&
-			(status === 'WAITING_INPUT' || status === 'REQUIRE_CORRECTION')
+			status === 'WAITING_INPUT' ||
+			status === 'REQUIRE_CORRECTION' ||
+			status === 'REQUIRE_CONTINUE'
 		) {
-			inputRef.current.focus()
+			const input = inputRef.current
+
+			if (document.activeElement === input) {
+				return
+			}
+
+			requestAnimationFrame(() => {
+				input.focus({preventScroll: true})
+				const valueLength = input.value.length
+				input.setSelectionRange(valueLength, valueLength)
+			})
 		}
 	}, [autoFocus, status])
 


### PR DESCRIPTION
## Summary
- restore the focus effect on the word-form input when returning to interactive states so mobile keyboards stay visible
- avoid redundant focusing by checking the current active element before triggering focus and selection

## Testing
- pnpm validate

------
https://chatgpt.com/codex/tasks/task_e_68d869ef81e08321a58ab84003536c16